### PR TITLE
Updates for non-standard TEMPLATES

### DIFF
--- a/adv_cache_tag/compat.py
+++ b/adv_cache_tag/compat.py
@@ -22,7 +22,7 @@ def get_template_libraries():
         from django.template.base import libraries
     except ImportError:
         # Django >= 1.9
-        from django.template import engines
-        libraries = engines['django'].engine.template_libraries
+        from django.template import Engine
+        libraries = Engine.get_default().template_libraries
 
     return libraries


### PR DESCRIPTION
Updates compat.get_template_libraries to work with TEMPLATES settings that do not include a "django" template.